### PR TITLE
Fix buildpack for Chrome 81.0.4044.9

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -395,11 +395,14 @@ case "$stack" in
       libatk1.0-0
       libatk-bridge2.0-0
       libcairo-gobject2
+      libdrm2
+      libgbm1
       libgconf-2-4
       libgtk-3-0
       libnspr4
       libnss3
       libx11-xcb1
+      libxcb-dri3-0
       libxcomposite1
       libxcursor1
       libxdamage1


### PR DESCRIPTION
As per https://github.com/heroku/heroku-buildpack-google-chrome/pull/85

Otherwise libxcb-dri3.so.0 may be reported as missing, which completely breaks this buildpack.

---

Generally, you should consider updating this as [there are some other minor commits in the Google Chrome buildpack](https://github.com/heroku/heroku-buildpack-google-chrome/commits/master) that are required. :smiley: 